### PR TITLE
Abort TCP connection request on .end()

### DIFF
--- a/lib/tcp_connection.js
+++ b/lib/tcp_connection.js
@@ -53,7 +53,7 @@ TCPConnection.prototype.connect = function(options, callback) {
 
 		var connectionEstablished = false;
 
-		var req = HTTP.request(url);
+		var req = this._request = HTTP.request(url);
 		req.end();
 		req.setTimeout(options.proxyTimeout || 5000);
 
@@ -113,6 +113,10 @@ TCPConnection.prototype._setupStream = function() {
 TCPConnection.prototype.end = function() {
 	if (this._stream) {
 		this._stream.end();
+	}
+
+	if (this._request) {
+		this._request.abort();
 	}
 };
 


### PR DESCRIPTION
Test:
```JS
const Steam = require('./');

const httpProxy = 'http://98.76.54.32';

const client = new Steam.CMClient();

client.on('debug', (...data) => console.log(...data));

client.setHttpProxy(httpProxy);

client.connect();
client.connect();
```

Before:
```
TypeError: self._connection.setTimeout is not a function
    at node-steam-client\lib\cm_client.js:175:21
```

After:
```
No error
```

Fixes #14