### PR TITLE
Bind context to TCPConnection.setTimeout

### DIFF
--- a/lib/tcp_connection.js
+++ b/lib/tcp_connection.js
@@ -107,7 +107,7 @@ TCPConnection.prototype._setupStream = function() {
 	this._stream.on('connect', function() { self.emit.apply(self, ['connect'].concat(Array.prototype.slice.call(arguments))); });
 	this._stream.on('end', function() { self.emit.apply(self, ['end'].concat(Array.prototype.slice.call(arguments))); });
 	this._stream.on('timeout', function() { self.emit.apply(self, ['timeout'].concat(Array.prototype.slice.call(arguments))); });
-	this.setTimeout = this._stream.setTimeout;
+	this.setTimeout = this._stream.setTimeout.bind(this._stream);
 };
 
 TCPConnection.prototype.end = function() {


### PR DESCRIPTION
Test:
```JS
const Steam = require('./');

const httpProxy = 'http://98.76.54.32';

const client = new Steam.CMClient();

client.on('debug', (...data) => console.log(...data));

client.setHttpProxy(httpProxy);
client.connect();
```

Before:
```
net.js:423
    this[kTimeout] = setUnrefTimeout(this._onTimeout.bind(this), msecs);
                                                     ^

TypeError: Cannot read property 'bind' of undefined
    at TCPConnection.Socket.setTimeout (net.js:423:54)
    at node-steam-client\lib\cm_client.js:175:21
```

After:
```
No error
```

Solves #16 